### PR TITLE
Fixed _rotateByDegrees

### DIFF
--- a/dist/customiseControls.js
+++ b/dist/customiseControls.js
@@ -553,7 +553,7 @@
          */
 
         _rotateByDegrees: function( e, target, value ) {
-            var angle = target.getAngle() + value,
+            var angle = parseInt(target.getAngle()) + value,
                 needsOriginRestore = false;
 
             if ( ( target.originX !== 'center' || target.originY !== 'center' ) && target.centeredRotation ) {


### PR DESCRIPTION
BUGFIX: _rotateByDegrees made an addition between a string and an integer. Added a parseInt on the string.
