### PR TITLE
fix(customiseControls): allow fetching for crossOrigin icons

### DIFF
--- a/dist/customiseControls.js
+++ b/dist/customiseControls.js
@@ -130,6 +130,7 @@
             icon.onerror = function() {
                 fabric.warn( this.src + ' icon is not an image' );
             };
+            icon.crossOrigin = "Anonymous";
 
             icon.src = iconUrl;
         },


### PR DESCRIPTION
This allows canvas to export an image with icons loaded from an external source. Otherwise, the following error will be prompted: `Uncaught SecurityError: Failed to execute 'toDataURL' on 'HTMLCanvasElement': Tainted canvases may not be exported.`
