### PR TITLE
Stroke corners if the cornerStrokeColor is set

### DIFF
--- a/dist/customiseControls.js
+++ b/dist/customiseControls.js
@@ -295,7 +295,7 @@
             }
 
             var size = this.cornerSize,
-                stroke = !this.transparentCorners && this.cornerStrokeColor,
+                cornerStroke = this.cornerStrokeColor || 'transparent',
                 cornerBG = this.cornerBackgroundColor || 'black',
                 cornerShape = this.cornerShape || 'rect',
                 cornerPadding = this.cornerPadding || 10;
@@ -310,20 +310,20 @@
                 if (cornerShape) {
                     ctx.globalAlpha = 1;
                     ctx.fillStyle = cornerBG;
+                    ctx.lineWidth = 2;
+                    ctx.strokeStyle = cornerStroke;
                     switch (cornerShape) {
                         case 'rect':
                             ctx.fillRect(left, top, size, size);
+                            ctx.strokeRect(left, top, size, size);
                             break;
                         case 'circle':
                             ctx.beginPath();
                             ctx.arc(left + size / 2, top + size / 2, size / 2, 0, 2 * Math.PI);
                             ctx.fill();
+                            ctx.stroke();
                             ctx.closePath();
                             break;
-                    }
-
-                    if (stroke) {
-                        ctx.stroke();
                     }
 
                     if (icon !== undefined) {
@@ -350,7 +350,7 @@
             } else {
                 isVML() || this.transparentCorners || ctx.clearRect(left, top, size, size);
                 ctx[methodName + 'Rect'](left, top, size, size);
-                if (stroke) {
+                if (!this.transparentCorners && this.cornerStrokeColor) {
                     ctx.strokeRect(left, top, size, size);
                 }
             }

--- a/dist/customiseControls.js
+++ b/dist/customiseControls.js
@@ -299,8 +299,14 @@
                 cornerBG = this.cornerBackgroundColor || 'black',
                 cornerShape = this.cornerShape || 'rect',
                 cornerPadding = this.cornerPadding || 10;
-
+                
             if (settings) {
+                if(settings.cornerSize){
+                    // Set the size, and also recalc left and top
+                    left = left + size/2 - settings.cornerSize/2;
+                    top = top + size/2 - settings.cornerSize/2;
+                    size = settings.cornerSize;
+                }
                 cornerShape = settings.cornerShape || cornerShape;
                 cornerBG = settings.cornerBackgroundColor || cornerBG;
                 cornerPadding = settings.cornerPadding || cornerPadding;

--- a/example/example.js
+++ b/example/example.js
@@ -97,6 +97,7 @@
             originX: 'center',
             originY: 'center',
             hasRotatingPoint: false,
+            cornerStrokeColor: 'blue'
         });
 
         // overwrite the prototype object based

--- a/example/example.js
+++ b/example/example.js
@@ -217,6 +217,7 @@
                     cornerShape: 'rect',
                     cornerBackgroundColor: randomColor(),
                     cornerPadding: 10,
+                    cornerSize: 35
                 },
             },
             tr: {
@@ -225,6 +226,7 @@
                     cornerShape: 'circle',
                     cornerBackgroundColor: randomColor(),
                     cornerPadding: 15,
+                    cornerSize: 15
                 },
             },
             bl: {


### PR DESCRIPTION
Currently it looks like even if the cornerStrokeColor is set, the _drawControl does not stroke the corner's border. 
* Added a fix so that cornerStrokeColor propagates through.
* Added an example for the cat image with this change ([see here](https://christinakayastha.github.io/fabricjs-customise-controls-extension/example/index.html))

Let me know if you have any feedback/suggestions!