### PR TITLE
Fixed correct skew for 'mt' and 'mb' controls when action override exists and altActionKey is pressed

### DIFF
--- a/dist/customiseControls.js
+++ b/dist/customiseControls.js
@@ -563,7 +563,7 @@
                         case 'mb':
                             if (e[this.altActionKey]) {
                                 return e[this.altActionKey]
-                                    ? 'skewY'
+                                    ? 'skewX'
                                     : 'scaleY';
                             }
                             return this[corner + 'Action'];


### PR DESCRIPTION
This looks like a small bug, since the default behavior when no alternative action exists is to skewX with the 'mt' and 'mb' controls.